### PR TITLE
Loading the package `CJKnumb' after xeCJK fix "Undefined control sequence"

### DIFF
--- a/common files/thesis-setting.tex
+++ b/common files/thesis-setting.tex
@@ -82,7 +82,10 @@
 
 %---------------------------------设置中文字体---------------------------------%
 \usepackage{fontspec}
+%xeCJK warning: "option-deprecated" 
+%The `CJKnumber' option is deprecated.
 \usepackage[SlantFont,BoldFont,CJKchecksingle,CJKnumber]{xeCJK}
+\usepackage{CJKnumb}
 % 使用 Adobe 字体
 \newcommand\adobeSog{Adobe Song Std}
 \newcommand\adobeHei{Adobe Heiti Std}

--- a/example/thesis-setting.tex
+++ b/example/thesis-setting.tex
@@ -82,7 +82,10 @@
 
 %---------------------------------设置中文字体---------------------------------%
 \usepackage{fontspec}
+%xeCJK warning: "option-deprecated" 
+%The `CJKnumber' option is deprecated.
 \usepackage[SlantFont,BoldFont,CJKchecksingle,CJKnumber]{xeCJK}
+\usepackage{CJKnumb}
 % 使用 Adobe 字体
 \newcommand\adobeSog{Adobe Song Std}
 \newcommand\adobeHei{Adobe Heiti Std}


### PR DESCRIPTION
你好，polossk。

我使用的软件版本是
XeTeX 3.14159265-2.6-0.99998 (TeX Live 2017)

默认的选项运行时会出现下面的问题（不影响PDF的渲染，但会中断make操作）：
> ! Undefined control sequence.
>
> \chaptername  ->第\CJKnumber 
>                             {\thechapter }章

警告信息显示如下：

> xeCJK warning: "option-deprecated"

>  The `CJKnumber' option is deprecated.

>  You may load the package `CJKnumb' after xeCJK to use its function.


在xeCJK后手动加载CJKnumb可以避免出现这个问题：
> \usepackage[xxx,xxx]{xeCJK}
> \usepackage{CJKnumb}

1. https://mirrors.ustc.edu.cn/CTAN/macros/xetex/latex/xecjk/xeCJK.pdf#12f
1. https://tex.stackexchange.com/questions/210397/renewcommand-the-chapter-in-chinese-problem
1. https://github.com/Pandoxie/FDU-Thesis-Latex/issues/1